### PR TITLE
Adding date scalars; reorganizing scalar code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,13 +12,12 @@
                  [mvxcvi/puget "1.0.2"]
                  [fipp "0.6.12"]
                  [funcool/cuerdas "2.0.5"]
-                 [aero "1.1.2"]
                  [io.aviso/pretty "0.1.34"]
-                 [com.walmartlabs/lacinia "0.24.0"]
+                 [com.walmartlabs/lacinia "0.25.0"]
                  [com.datomic/datomic-pro "0.9.5656" :scope "provided"]
                  [clojure.java-time "0.3.1"]
                  [org.clojure/tools.logging "0.4.0"]
-                 [org.clojure/tools.reader "1.2.1"]]
+                 [org.clojure/tools.reader "1.2.2"]]
 
   :plugins [[s3-wagon-private "1.3.1" :exclusions [commons-logging]]]
 
@@ -43,13 +42,13 @@
                                       [lein-shell "0.5.0"]
                                       [com.jakemccrary/lein-test-refresh "0.22.0"]]
                        :dependencies [[vvvvalvalval/datomock "0.2.0"]
-                                      [io.forward/yaml "1.0.6"]
+                                      [io.forward/yaml "1.0.7"]
                                       [org.apache.logging.log4j/log4j-core "2.10.0"]
                                       [org.apache.logging.log4j/log4j-slf4j-impl "2.10.0"]
                                       [com.datomic/datomic-pro "0.9.5656"
                                        :exclusions [org.slf4j/slf4j-nop]]]}
              :docs    {:plugins      [[lein-codox "0.10.3"]
-                                      [lein-asciidoctor "0.1.14" :exclusions [org.slf4j/slf4j-api]]]
+                                      [lein-asciidoctor "0.1.15" :exclusions [org.slf4j/slf4j-api]]]
                        :dependencies [[codox-theme-rdash "0.1.2"]]}
              :ancient {:plugins [[lein-ancient "0.6.15"
                                   :exclusions [commons-logging
@@ -58,6 +57,8 @@
                                                com.fasterxml.jackson.core/jackson-databind]]]}
              :ultra   {:plugins [[venantius/ultra "0.5.2" :exclusions [org.clojure/clojure]]]}
              :test    {:resource-paths ["test/resources"]}}
+
+  :aliases {"refresh" ["with-profile" "+ultra" "test-refresh" ":watch"]}
 
   :release-tasks [;; Make sure we're up to date
                   ["vcs" "assert-committed"]

--- a/resources/stillsuit/base-schema.edn
+++ b/resources/stillsuit/base-schema.edn
@@ -1,0 +1,43 @@
+;; Base stillsuit config file. The schema passed to (stillsuit/decorate) is deep-merged
+;; over this file.
+{:stillsuit/version
+ "0.5.0"
+
+ ;; Scalar definitions - see stillsuit.lacinia.scalars for their implementations
+ :scalars
+ {:JavaBigDec
+  {:description "A Java BigDecimal value, serialized as a string."
+   :parse       :stillsuit.parse/bigdec
+   :serialize   :stillsuit.serialize/str}
+  :JavaBigInt
+  {:description "A Java BigInteger value, serialized as a string."
+   :parse       :stillsuit.parse/bigint
+   :serialize   :stillsuit.serialize/str}
+  :JavaLong
+  {:description "A Java long value, serialized as a string (because it can be more than 32 bits)."
+   :parse       :stillsuit.parse/long
+   :serialize   :stillsuit.serialize/str}
+  :ClojureKeyword
+  {:description "A Clojure keyword value, serialized as a string omitting the leading colon."
+   :parse       :stillsuit.parse/keyword
+   :serialize   :stillsuit.serialize/keyword-no-colon}
+  :ClojureKeywordWithColon
+  {:description "A Clojure keyword value, serialized as a string including the leading colon."
+   :parse       :stillsuit.parse/keyword
+   :serialize   :stillsuit.serialize/keyword-with-colon}
+  :Iso8601Date
+  {:description "A java.util.Date value, serialized as an ISO-8601 string in the UTC time zone."
+   :parse       :stillsuit.parse/iso8601
+   :serialize   :stillsuit.serialize/iso8601}
+  :EpochMillisecs
+  {:description "A java.util.Date value, serialized as the number of milliseconds since the UTC epoch."
+   :parse       :stillsuit.parse/epoch-millisecs
+   :serialize   :stillsuit.serialize/epoch-millisecs}
+  :JavaDouble
+  {:description "A Java double or float value, serialized as a string."
+   :parse       :stillsuit.parse/double
+   :serialize   :stillsuit.serialize/str}
+  :JavaUUID
+  {:description "A java.util.UUID value, serialized as a string."
+   :parse       :stillsuit.parse/uuid
+   :serialize   :stillsuit.serialize/str}}}

--- a/resources/stillsuit/config-defaults.edn
+++ b/resources/stillsuit/config-defaults.edn
@@ -1,0 +1,8 @@
+;; Default stillsuit configuration options. Any options passed to `(stillsuit/decorate)`
+;; will be deep-merged on top of this default map.
+{:stillsuit/datomic-entity-type     :DatomicEntity
+ :stillsuit/entity-id-query-name    :entity_by_eid
+ :stillsuit/query-by-unique-id-name :entity_by_unique_id
+ :stillsuit/no-default-resolver?    false
+ :stillsuit/no-scalars?             false
+ :stillsuit/compile?                true}

--- a/resources/stillsuit/stillsuit.edn
+++ b/resources/stillsuit/stillsuit.edn
@@ -1,1 +1,0 @@
-;; Main stillsuit configuration file

--- a/src/stillsuit/lacinia/scalars.clj
+++ b/src/stillsuit/lacinia/scalars.clj
@@ -1,56 +1,15 @@
 (ns stillsuit.lacinia.scalars
   (:require [com.walmartlabs.lacinia.schema :as schema]
             [clojure.tools.logging :as log]
-            [clojure.edn :as edn])
+            [clojure.edn :as edn]
+            [clojure.string :as str])
   (:import (java.util Date UUID)
-           (java.time ZonedDateTime))
-  (:refer-clojure :exclude [read-string]))
-
-(def scalar-options
-  "Map from datomic db.type values to data for custom scalars"
-  {:db.type/bigdec
-   {::scalar      :JavaBigDec
-    ::parse       :stillsuit.scalars/parse-bigdec
-    ::description "A Java BigDecimal value, serialized as a string."}
-   :db.type/bigint
-   {::scalar      :JavaBigInt
-    ::parse       :stillsuit.scalars/parse-bigint
-    ::description "A Java BigInteger value, serialized as a string."}
-   :db.type/long
-   {::scalar      :JavaLong
-    ::description "A Java long value, serialized as a string (because it can be more than 32 bits)."}
-   :db.type/keyword
-   {::scalar      :ClojureKeyword
-    ::description "A Clojure keyword value, serialized as a string."}
-   :db.type/instant
-   {::scalar      :JavaDate
-    ::serialize   :stillsuit.scalars/serialize-java-date
-    ::parse       :stillsuit.scalars/parse-java-date
-    ::description "A java.util.Date value, serialized as an ISO-8601 string in the UTC time zone."}
-   :db.type/float
-   {::scalar      :JavaDouble
-    ::parse       :stillsuit.scalars/parse-double
-    ::description "A Java float value, serialized as a string."}
-   :db.type/double
-   {::scalar      :JavaDouble
-    ::parse       :stillsuit.scalars/parse-double
-    ::description "A Java double value, serialized as a string."}
-   :db.type/uuid
-   {::scalar      :JavaUUID
-    ::parse       :stillsuit.scalars/parse-uuid
-    ::description "A java.util.UUID value, serialized as a string."}})
-
-(defn attach-scalar [scalars db-type]
-  (let [{:keys [::scalar ::parse ::serialize ::description]} (get scalar-options db-type)]
-    (assoc scalars scalar {:parse       (or parse :stillsuit.scalars/parse-edn)
-                           :serialize   (or serialize :stillsuit.scalars/serialize-str)
-                           :description description})))
-
-(defn- attach-overrides
-  [schema overrides]
-  (assoc schema :scalars (reduce attach-scalar (:scalars schema) overrides)))
+           (java.time OffsetDateTime LocalDateTime ZoneOffset Instant)
+           (java.time.format DateTimeFormatter)
+           (clojure.lang Keyword)))
 
 (def parse-edn
+  "Parse the incoming string as EDN."
   (schema/as-conformer edn/read-string))
 
 (def serialize-str
@@ -59,51 +18,91 @@
 (def serialize-pr-str
   (schema/as-conformer pr-str))
 
-(def serialize-java-date
+(def parse-iso8601
+  "Parser which will parse dates in ISO-8601 format, convert them to UTC time, and return
+  a `java.util.Date` result."
+  (schema/as-conformer
+   (fn [^String date-str]
+     ;; Java time libraries, from Hell's heart I stab at thee
+     (-> date-str
+         (LocalDateTime/parse DateTimeFormatter/ISO_DATE_TIME)
+         (.toInstant ZoneOffset/UTC)
+         Date/from))))
+
+(def serialize-iso8601
+  "Serializer which will serialize dates as ISO-8601 strings in the UTC timezone."
   (schema/as-conformer
    (fn [^Date date]
      (-> date
          .toInstant
+         (OffsetDateTime/ofInstant ZoneOffset/UTC)
+         (.format DateTimeFormatter/ISO_DATE_TIME)))))
+
+(def parse-epoch-millisecs
+  "Parser converting number of milliseconds since the UTC epoch (as a string) to a
+  `java.util.Date` value."
+  (schema/as-conformer
+   (fn [^String msec-str]
+     (-> msec-str
+         Long/parseLong
+         Instant/ofEpochMilli
+         Date/from))))
+
+(def serialize-epoch-millisecs
+  "Serializer representing a `java.util.Date` object as a string representing the number
+  of milliseconds since the UTC epoch."
+  (schema/as-conformer
+   (fn [^Date date]
+     (-> date
+         .getTime
          .toString))))
 
 (def parse-uuid
   (schema/as-conformer (fn [^String u] (UUID/fromString u))))
 
-(def parse-java-date
-  (schema/as-conformer
-   (fn [^String d]
-     ;; Java time libraries, from Hell's heart I stab at thee
-     (-> (ZonedDateTime/parse d)
-         .toInstant
-         Date/from))))
-
 (defn parse-as-value
   [type-convert]
-  (schema/as-conformer (fn [^String k]
-                         (type-convert (edn/read-string k)))))
+  (schema/as-conformer (fn [^String k] (type-convert k))))
+
+(defn- strip-leading-colons
+  [s]
+  (str/replace s #"^:+" ""))
+
+(def keyword-parser
+  (schema/as-conformer
+   (fn keyword-parse-fn
+     [^String keyword-str]
+     (-> keyword-str
+         strip-leading-colons
+         keyword))))
+
+(defn keyword-serializer
+  [with-colon?]
+  (let [colon-xform (if with-colon? identity strip-leading-colons)]
+    (schema/as-conformer
+     (fn keyword-serialize-fn
+       [^Keyword k]
+       (-> k
+           str
+           colon-xform)))))
 
 (defn transformer-map
   "Given a base resolver map used attach scalar transformers to a lacinia schema, attach the
   transformers for datomic primitive types."
   [base-map config]
   (merge base-map
-         {:stillsuit.scalars/parse-edn           parse-edn
-          :stillsuit.scalars/serialize-str       serialize-str
-          :stillsuit.scalars/serialize-java-date serialize-java-date
-          :stillsuit.scalars/serialize-pr-str    serialize-pr-str
-          :stillsuit.scalars/parse-uuid          parse-uuid
-          :stillsuit.scalars/parse-java-date     parse-java-date
-          :stillsuit.scalars/parse-bigint        (parse-as-value bigint)
-          :stillsuit.scalars/parse-bigdec        (parse-as-value bigdec)
-          :stillsuit.scalars/parse-double        (parse-as-value double)}))
-
-(defn attach-scalars
-  "Given a lacinia schema, add in the scalar transformer definitions to convert from datomic
-  types to serialized GraphQL values."
-  [schema {:keys [:stillsuit/scalars] :as config}]
-  (cond-> schema
-          (not (:stillsuit.scalar/skip-defaults? config))
-          (attach-overrides (-> scalar-options keys set))
-
-          (set? (:stillsuit.scalar/for-fields scalars))
-          (attach-overrides (:stillsuit.scalar/for-fields scalars))))
+         {:stillsuit.parse/edn                    parse-edn
+          :stillsuit.parse/uuid                   parse-uuid
+          :stillsuit.parse/iso8601                parse-iso8601
+          :stillsuit.parse/epoch-millisecs        parse-epoch-millisecs
+          :stillsuit.parse/keyword                keyword-parser
+          :stillsuit.parse/long                   (parse-as-value #(Long/parseLong ^String %))
+          :stillsuit.parse/bigint                 (parse-as-value bigint)
+          :stillsuit.parse/bigdec                 (parse-as-value bigdec)
+          :stillsuit.parse/double                 (parse-as-value #(Double/parseDouble ^String %))
+          :stillsuit.serialize/iso8601            serialize-iso8601
+          :stillsuit.serialize/str                serialize-str
+          :stillsuit.serialize/pr-str             serialize-pr-str
+          :stillsuit.serialize/epoch-millisecs    serialize-epoch-millisecs
+          :stillsuit.serialize/keyword-with-colon (keyword-serializer true)
+          :stillsuit.serialize/keyword-no-colon   (keyword-serializer false)}))

--- a/test/resources/test-schemas/rainbow/datomic.edn
+++ b/test/resources/test-schemas/rainbow/datomic.edn
@@ -8,6 +8,9 @@
   {:db/ident       :rainbow/one-keyword
    :db/valueType   :db.type/keyword
    :db/cardinality :db.cardinality/one}
+  {:db/ident       :rainbow/two-keyword
+   :db/valueType   :db.type/keyword
+   :db/cardinality :db.cardinality/one}
   {:db/ident       :rainbow/one-string
    :db/valueType   :db.type/string
    :db/cardinality :db.cardinality/one}
@@ -35,6 +38,9 @@
   {:db/ident       :rainbow/one-instant
    :db/valueType   :db.type/instant
    :db/cardinality :db.cardinality/one}
+  {:db/ident       :rainbow/two-instant
+   :db/valueType   :db.type/instant
+   :db/cardinality :db.cardinality/one}
   {:db/ident       :rainbow/one-uuid
    :db/valueType   :db.type/uuid
    :db/cardinality :db.cardinality/one}
@@ -49,6 +55,7 @@
  [{:db/id               "one"
    :rainbow/id          111
    :rainbow/one-keyword :my.keyword/value
+   :rainbow/two-keyword :my.keyword/value
    :rainbow/one-string  "One string"
    :rainbow/one-boolean true
    :rainbow/one-long    149
@@ -57,11 +64,13 @@
    :rainbow/one-double  132.45
    :rainbow/one-bigdec  123.45M
    :rainbow/one-instant #inst "2018-01-01T01:01:01Z"
+   :rainbow/two-instant #inst "2018-01-01T01:01:01Z"
    :rainbow/one-uuid    #uuid "fcc81e3e-f301-11e7-8a4d-4762cfbddccf"
    :rainbow/one-ref     "two"}
   {:db/id               "two"
    :rainbow/id          222
    :rainbow/one-keyword :my.keyword/value
+   :rainbow/two-keyword :my.keyword/value
    :rainbow/one-string  "Two string"
    :rainbow/one-boolean true
    :rainbow/one-long    249
@@ -70,5 +79,6 @@
    :rainbow/one-double  232.45
    :rainbow/one-bigdec  223.45M
    :rainbow/one-instant #inst "2018-02-02T02:02:02Z"
+   :rainbow/two-instant #inst "2018-02-02T02:02:02Z"
    :rainbow/one-uuid    #uuid "796ddd5e-f3b4-11e7-82d5-0747e98878c6"}]]
 ;:rainbow/one-uri     #java.net.URI["https://clojure.org"]}]]

--- a/test/resources/test-schemas/rainbow/lacinia.edn
+++ b/test/resources/test-schemas/rainbow/lacinia.edn
@@ -20,14 +20,16 @@
   {:description "I've got one of everything"
    :fields      {:id         {:type ID}
                  :oneString  {:type String}
-                 :oneKeyword {:type :ClojureKeyword}
+                 :oneKeyword {:type :ClojureKeywordWithColon}
+                 :twoKeyword {:type :ClojureKeyword}
                  :oneBoolean {:type Boolean}
                  :oneLong    {:type :JavaLong}
                  :oneBigint  {:type :JavaBigInt}
                  :oneFloat   {:type Float}
                  :oneDouble  {:type Float}
                  :oneBigdec  {:type :JavaBigDec}
-                 :oneInstant {:type :JavaDate}
+                 :oneInstant {:type :Iso8601Date}
+                 :twoInstant {:type :EpochMillisecs}
                  :oneUuid    {:type :JavaUUID}
                  :oneRef     {:type :Rainbow}}}}
  :queries
@@ -74,26 +76,16 @@
   {:type    (non-null Boolean)
    :args    {:value    {:type (non-null :JavaDouble)}
              :expected {:type (non-null String)}}
+   :resolve :rainbow/typecheck}
+
+  :typecheck_epoch_ms
+  {:type    (non-null Boolean)
+   :args    {:value    {:type (non-null :EpochMillisecs)}
+             :expected {:type (non-null String)}}
+   :resolve :rainbow/typecheck}
+
+  :typecheck_iso8601
+  {:type    (non-null Boolean)
+   :args    {:value    {:type (non-null :Iso8601Date)}
+             :expected {:type (non-null String)}}
    :resolve :rainbow/typecheck}}}
-
-  ;:echo_double
-  ;{:type    :JavaBigDec
-  ; :args    {:id {:type :JavaBigDec}}
-  ; :resolve :rainbow/identity}
-  ;
-  ;:echo_instant
-  ;{:type    :JavaDate
-  ; :args    {:id {:type :JavaDate}}
-  ; :resolve :rainbow/identity}}}
-
-
-;:mutations
-;{:echo
-; {:type        :Rainbow
-;  :description "Return input"
-;  :args        {:keyword {:type :ClojureKeyword}
-;                :uuid    {:type :JavaUUID}
-;                :date    {:type :JavaDate}
-;                :bigdec  {:type :JavaBigDec}
-;                :bigint  {:type :JavaBigInt}}
-;  :resolve     :mutation/echo}}}}

--- a/test/resources/test-schemas/rainbow/queries.yaml
+++ b/test/resources/test-schemas/rainbow/queries.yaml
@@ -5,6 +5,7 @@ nil-result:
       rainbowById(id: 7777) {
         oneString
         oneKeyword
+        twoKeyword
         oneBoolean
         oneLong
         oneBigint
@@ -29,6 +30,7 @@ one-result:
       rainbowById(id: 111) {
         oneString
         oneKeyword
+        twoKeyword
         oneBoolean
         oneLong
         oneBigint
@@ -36,6 +38,7 @@ one-result:
         oneDouble
         oneBigdec
         oneInstant
+        twoInstant
         oneUuid
         oneRef {
           id
@@ -51,7 +54,9 @@ one-result:
        :oneDouble 132.45
        :oneFloat 132.45
        :oneInstant "2018-01-01T01:01:01Z"
+       :twoInstant "1514768461000"
        :oneKeyword ":my.keyword/value"
+       :twoKeyword "my.keyword/value"
        :oneLong "149"
        :oneRef {:id "222"}
        :oneString "One string"
@@ -104,3 +109,15 @@ typecheck_double2:
     { typecheck_double(value: "12", expected: "12.34") }
   response: |-
     {:data {:typecheck_double true}}
+
+typecheck_epoch_ms:
+  query: |-
+    { typecheck_epoch_ms(value: "1234567890", expected: "#inst \"2018-01-01T01:01:01Z\"") }
+  response: |-
+    {:data {:typecheck_epoch_ms true}}
+
+typecheck_iso8601:
+  query: |-
+    { typecheck_iso8601(value: "2018-01-01T01:01:01Z", expected: "#inst \"2018-01-01T01:01:01Z\"") }
+  response: |-
+    {:data {:typecheck_iso8601 true}}

--- a/test/stillsuit/test/scalars.clj
+++ b/test/stillsuit/test/scalars.clj
@@ -19,6 +19,8 @@
   (let [val-type    (type value)
         expect-val  (edn/read-string expected)
         expect-type (type expect-val)]
+    (when (not= val-type expect-type)
+      (log/warnf "Typecheck failed: expected %s, got %s" (str expect-type) (str val-type)))
     (= val-type expect-type)))
 
 (defn- rainbow-by-id [{:keys [:stillsuit/connection]} {:keys [id]} _]
@@ -35,7 +37,7 @@
 (deftest test-rainbow-queries
   (try
     (fixtures/verify-queries!
-      (fixtures/load-setup :rainbow rainbow-resolver-map))
+     (fixtures/load-setup :rainbow rainbow-resolver-map))
 
     (catch Exception e
       (.printStackTrace e))))


### PR DESCRIPTION
A few updates here in support of the catchpocket code which is coming soon.

- Slurped in the `:EpochMillisecs` scalar transformer from OCP
- Renamed the existing Date parser to `:Iso8601Date` which will hopefully make the intent more clear
- Added some tests for both of the above
- Reorganized how the scalar-transformer stuff is implemented - the structure it was in made sense for catchpocket but not stillsuit, and in the new world the base data looks more like a regular snippet of a lacinia config file
- Added some base EDN files for the stillsuit schema and config settings (these used to live in code)