### PR TITLE
Using :JavaLong scalar as :db/id type

### DIFF
--- a/src/stillsuit/core.clj
+++ b/src/stillsuit/core.clj
@@ -53,7 +53,7 @@
   "Main interface to stillsuit. Accepts a map containing various parameters as input; returns
   a map with an app context and a schema."
   [{:stillsuit/keys [schema config resolvers transformers context connection]}]
-  (let [opts         (merge @default-config-schema config)
+  (let [opts         (merge @default-config-schema (:stillsuit/config schema) config)
         uncompiled   (-> @base-schema
                          (slu/deep-map-merge schema)
                          (sq/attach-queries opts)

--- a/src/stillsuit/lacinia/resolvers.clj
+++ b/src/stillsuit/lacinia/resolvers.clj
@@ -107,7 +107,7 @@
   [config]
   (let [db-id (:stillsuit/db-id-name config :dbId)]
     {:description "Base type for datomic entities"
-     :fields      {db-id {:type        'ID
+     :fields      {db-id {:type        :JavaLong
                           :description "The entity's EID (as a string)"}}}))
 
 (defn attach-resolvers [schema config]


### PR DESCRIPTION
Two small changes in here related to catchpocket goings-on:

- Use the built-in (to stillsuit) `:JavaLong` scalar as the declared type of the `:db/id` entity
- Allow part of the stillsuit configuration to be specified by reading a `:stillsuit/config` key in the schema file

In the current stillsuit setup, nothing is actually using this interface, so this should be neutral for our current graphql stuff. The purpose behind this is to allow catchpocket to expose the `:db/id` field as either `:dbId` or `:db_id` depending on how the catchpocket user has configured it.