### PR TITLE
Coercing nil values to false for boolean fields

### DIFF
--- a/src/stillsuit/core.clj
+++ b/src/stillsuit/core.clj
@@ -5,6 +5,7 @@
             [stillsuit.lacinia.enums :as se]
             [stillsuit.lib.util :as slu]
             [datomic.api :as d]
+            [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.schema :as schema]
             [clojure.tools.logging :as log]
             [com.walmartlabs.lacinia.util :as util]))
@@ -70,3 +71,12 @@
       (log/spy :trace uncompiled))
     {:stillsuit/schema      compiled
      :stillsuit/app-context (make-app-context context schema connection enum-map opts)}))
+
+(defn execute
+  "Convenience function to take the result of (decorate) and execute a query against it."
+  ([stillsuit-result query]
+   (execute stillsuit-result query nil))
+  ([stillsuit-result query variables]
+   (let [schema  (:stillsuit/schema stillsuit-result)
+         context (:stillsuit/app-context stillsuit-result)]
+     (lacinia/execute schema query variables context))))

--- a/test/resources/test-schemas/rainbow/datomic.edn
+++ b/test/resources/test-schemas/rainbow/datomic.edn
@@ -17,6 +17,9 @@
   {:db/ident       :rainbow/one-boolean
    :db/valueType   :db.type/boolean
    :db/cardinality :db.cardinality/one}
+  {:db/ident       :rainbow/two-boolean
+   :db/valueType   :db.type/boolean
+   :db/cardinality :db.cardinality/one}
   {:db/ident       :rainbow/one-long
    :db/valueType   :db.type/long
    :db/cardinality :db.cardinality/one}

--- a/test/resources/test-schemas/rainbow/lacinia.edn
+++ b/test/resources/test-schemas/rainbow/lacinia.edn
@@ -23,6 +23,14 @@
                  :oneKeyword {:type :ClojureKeywordWithColon}
                  :twoKeyword {:type :ClojureKeyword}
                  :oneBoolean {:type Boolean}
+
+                 ;; Following uses a ref resolver to test boolean coercion. Because the
+                 ;; :lacinia-type argument is 'Boolean, entities with missing attribute
+                 ;; values for this field return false for the value.
+                 :twoBoolean {:type    (non-null Boolean)
+                              :resolve [:stillsuit/ref
+                                        #:stillsuit{:attribute    :rainbow/two-boolean
+                                                    :lacinia-type Boolean}]}
                  :oneLong    {:type :JavaLong}
                  :oneBigint  {:type :JavaBigInt}
                  :oneFloat   {:type Float}

--- a/test/resources/test-schemas/rainbow/queries.yaml
+++ b/test/resources/test-schemas/rainbow/queries.yaml
@@ -121,3 +121,18 @@ typecheck_iso8601:
     { typecheck_iso8601(value: "2018-01-01T01:01:01Z", expected: "#inst \"2018-01-01T01:01:01Z\"") }
   response: |-
     {:data {:typecheck_iso8601 true}}
+
+# This query tests coercion of missing attributes to false (this entity doesn't have a value
+# for two-boolean, but we don't want to return nil).
+bool-coercion:
+  query: |-
+    {
+      rainbowById(id: 111) {
+        twoBoolean
+      }
+    }
+  response: |-
+    {:data
+     {:rainbowById
+      {:twoBoolean false}}}
+


### PR DESCRIPTION
This change adds some code in the `:stillsuit/ref` resolver to ensure that fields declared as `Boolean` (in the resolver args) always return either true or false (and not nil) - in particular, if you declare a field as `Boolean` and the underlying datomic attribute isn't present, this code will return `false` instead of `nil`.

A user of the library could arguably want a SQL-style trinary system where `false` and `nil` are logically distinct, but given Clojure's general attitude about falsiness this seems like reasonable behavior to me. In any event, this fixes a specific bug @dimakruk reported with the `isVerified` field on `Person`s.

I also added a little convenience wrapper function to execute a query given the results of `(stillsuit/decorate)`, and rearranged a bit of the test code slightly around that.