### PR TITLE
Entity filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           path: target/manual
   doc-deploy:
     <<: *docker_defaults
-    working_directory: ~/project/docs
+    working_directory: ~/project/doc
     steps:
       - checkout
       - <<: *restore_anchor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - Lots of docs updates, `(stillsuit/connection)` and friends
+- Entity filters for ref resolvers
 
 ## [0.3.0] - 2018-02-14 💝
 ### Added

--- a/doc/manual/index.adoc
+++ b/doc/manual/index.adoc
@@ -315,6 +315,18 @@ NOTE: These two fields are fine for simple fields whose sort order you know ahea
 but if you need more complex behavior, including pagination, you'll probably want to write
 a custom resolver.
 
+==== :stillsuit/entity-filter
+
+This option references an entity filter for the attribute - see below.
+
+== Entity Filters
+
+Entity filters allow you to attach a filter to any field in order to limit the set of
+entities that are returned from a given field resolver. The filter has access to the
+application context as well as the entity, so it can be used as a security measure.
+
+(More docs TBD)
+
 == Writing Query Resolvers
 
 In stillsuit we use the term "query resolver" to refer to a lacinia resolver that returns one or more

--- a/test/resources/test-schemas/music/datomic.edn
+++ b/test/resources/test-schemas/music/datomic.edn
@@ -36,7 +36,7 @@
    :db/cardinality :db.cardinality/one}
   {:db/ident       :track/position
    :db/valueType   :db.type/long
-   :db/cardinality :db.cardinality/many}]
+   :db/cardinality :db.cardinality/one}]
 
  ;; Data
  [{:db/id       "crass"

--- a/test/resources/test-schemas/music/lacinia.edn
+++ b/test/resources/test-schemas/music/lacinia.edn
@@ -4,7 +4,7 @@
   {:description "Artist"
    :fields      {:id     {:type (non-null ID)}
                  :name   {:type (non-null String)}
-                 :albums {:type (list (non-null :Album))
+                 :albums {:type    (list (non-null :Album))
                           ;; This resolver factory tells stillsuit to resolve `albums` using
                           ;; the datomic attribute `:artist/albums`, and to sort the resulting
                           ;; set by the `album/year` attribute of the referred entities
@@ -23,6 +23,14 @@
                  ;; :album/tracks from the type and field name.
                  :tracks {:type (list (non-null :Track))}
 
+                 ;; This reference uses an entity filter that only returns the first track.
+                 :first  {:type    :Track
+                          :resolve [:stillsuit/ref
+                                    #:stillsuit{:attribute     :album/tracks
+                                                :lacinia-type  :Track
+                                                :cardinality   :stillsuit.cardinality/one
+                                                :entity-filter :music-filter/first-track}]}
+
                  ;; This resolver factory tells stillsuit to use the `:artist/_albums`
                  ;; backreference to go from an album to its artist. The `:stillsuit/cardinality`
                  ;; key with value :stillsuit.cardinality/one tells stillsuit to return a single
@@ -35,8 +43,9 @@
 
   :Track
   {:description "Track"
-   :fields      {:id   {:type (non-null ID)}
-                 :name {:type (non-null String)}}}}
+   :fields      {:id       {:type (non-null ID)}
+                 :position {:type (non-null Int)}
+                 :name     {:type (non-null String)}}}}
 
  :queries
  {:artist_by_id

--- a/test/resources/test-schemas/music/queries.yaml
+++ b/test/resources/test-schemas/music/queries.yaml
@@ -79,3 +79,16 @@ album_backref:
     }
   response: |-
     {:data {:album_by_id {:artist {:name "Crass" :id "1"}}}}
+
+album_filter:
+  query: |-
+    {
+      album_by_id(id: "2") {
+        first {
+          position
+          name
+        }
+      }
+    }
+  response: |-
+    {:data {:album_by_id {:first {:position 1 :name "Asylum"}}}}

--- a/test/stillsuit/test/resolvers.clj
+++ b/test/stillsuit/test/resolvers.clj
@@ -26,9 +26,15 @@
              (map (partial d/entity db))
              (sort-by :artist/name))))
 
+(defn first-track-filter [opts context entity]
+  (= (:track/position entity) 1))
+
 (def music-resolver-map
   {:query/artist-by-id get-artist-by-id
    :query/all-artists  get-all-artists})
 
+(def filters
+  {:music-filter/first-track first-track-filter})
+
 (deftest test-music-queries
-  (fixtures/verify-queries! (fixtures/load-setup :music music-resolver-map)))
+  (fixtures/verify-queries! (fixtures/load-setup :music music-resolver-map filters)))

--- a/test/stillsuit/test_util/fixtures.clj
+++ b/test/stillsuit/test_util/fixtures.clj
@@ -96,14 +96,17 @@
   can be passed to (execute-query) for further testing."
   ([db-name resolver-map]
    (load-setup db-name resolver-map nil))
-  ([db-name resolver-map overrides]
+  ([db-name resolver-map filters]
+   (load-setup db-name resolver-map filters nil))
+  ([db-name resolver-map filters overrides]
    (let [config    (get-config db-name)
          schema    (get-schema db-name)
          queries   (get-query-doc db-name)
-         decorated (stillsuit/decorate #:stillsuit{:schema     schema
-                                                   :config     config
-                                                   :connection (get-connection db-name)
-                                                   :resolvers  resolver-map})]
+         decorated (stillsuit/decorate #:stillsuit{:schema         schema
+                                                   :config         config
+                                                   :entity-filters filters
+                                                   :connection     (get-connection db-name)
+                                                   :resolvers      resolver-map})]
      (util/deep-map-merge {::context   (:stillsuit/app-context decorated)
                            ::config    config
                            ::schema    (:stillsuit/schema decorated)


### PR DESCRIPTION
This PR adds in an entity-filter mechanism to stillsuit. With this in place, calling code can attach a filter function to any field. The filter function gets the application context and an entity; if it returns `false`, the entity will be omitted from the set of responses for that field.

Calling code can use this mechanism to implement some graph-level security by stashing the user-id of a logged-in user in the app context and then referencing it in the entity filters to limit what a particular user can see.