### PR TITLE
Fix for empty cardinality-many items coming back as (nil)

### DIFF
--- a/src/stillsuit/lacinia/resolvers.clj
+++ b/src/stillsuit/lacinia/resolvers.clj
@@ -94,6 +94,7 @@
                               (constantly true))
                             referenced-filter)]
     (->> entity-set
+         (remove nil?)
          (filter (partial filter-fn opts context))
          (entity-sort opts))))
 


### PR DESCRIPTION
Previous version of this was returning `(nil)` instead of `()` in cases where a `:cardinality/many` attribute returned `nil`.