### PR TITLE
properly support non datomic entities in stillsuit/ref resolver for cardinality/many

### DIFF
--- a/src/stillsuit/lacinia/resolvers.clj
+++ b/src/stillsuit/lacinia/resolvers.clj
@@ -104,11 +104,11 @@
   [{:stillsuit/keys [attribute lacinia-type] :as opts}]
   ^resolve/ResolverResult
   (fn [context args entity]
-    (let [value    (ensure-type (get entity attribute) lacinia-type)
-          val-set? (set? value)
-          val-list (if val-set? value #{value})
-          filtered (sort-and-filter-entities opts context val-list)
-          [sorted errs] (ensure-cardinality opts val-set? filtered)]
+    (let [value     (ensure-type (get entity attribute) lacinia-type)
+          val-coll? (coll? value)
+          val-list  (if val-coll? (set value) #{value})
+          filtered  (sort-and-filter-entities opts context val-list)
+          [sorted errs] (ensure-cardinality opts val-coll? filtered)]
       (resolve/resolve-as
        (schema/tag-with-type sorted lacinia-type)
        errs))))


### PR DESCRIPTION
when using the `stillsuit/ref` resolver with `cardinality/many` stillsuit would improperly resolve fields that weren't sets. This is because stillsuit expected to only get sets back from datomic.

This fix allows non datomic entities to be properly resolved