### PR TITLE
Tim/upgrade lacinia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.15.0] - 2018-03-12
+### Added
+
+- Updated to latest lacinia
+- Some bugfixes around cardinality-many attributes and enums
+
 ## [0.14.0] - 2018-09-28
 ### Added
 

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [fipp "0.6.12"]
                  [funcool/cuerdas "2.0.6"]
                  [io.aviso/pretty "0.1.34"]
-                 [com.walmartlabs/lacinia "0.29.0"]
+                 [com.walmartlabs/lacinia "0.32.0"]
                  ;; why the below isn't transitively picked up from lacinia is a mystery to me
                  [org.clojure/data.json "0.2.6"]
                  [clojure.java-time "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "Apache 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
 
-  :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
+  :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
                  [org.clojure/tools.cli "0.4.1"]
                  [mvxcvi/puget "1.1.0"]
                  [fipp "0.6.17"]
@@ -16,6 +16,7 @@
                  [com.walmartlabs/lacinia "0.32.0"]
                  [clojure.java-time "0.3.2"]
                  [org.clojure/tools.logging "0.4.1"]
+                 [org.clojure/tools.reader "1.3.2"]
                  [com.datomic/datomic-free "0.9.5697"
                   :optional true
                   :scope "provided"

--- a/project.clj
+++ b/project.clj
@@ -7,19 +7,15 @@
   :license {:name "Apache 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/core.async "0.4.474"]
+  :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/tools.cli "0.4.1"]
-                 [mvxcvi/puget "1.0.2"]
-                 [fipp "0.6.12"]
-                 [funcool/cuerdas "2.0.6"]
-                 [io.aviso/pretty "0.1.34"]
+                 [mvxcvi/puget "1.1.0"]
+                 [fipp "0.6.17"]
+                 [funcool/cuerdas "2.1.0"]
+                 [io.aviso/pretty "0.1.37"]
                  [com.walmartlabs/lacinia "0.32.0"]
-                 ;; why the below isn't transitively picked up from lacinia is a mystery to me
-                 [org.clojure/data.json "0.2.6"]
                  [clojure.java-time "0.3.2"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/tools.reader "1.3.0"]
                  [com.datomic/datomic-free "0.9.5697"
                   :optional true
                   :scope "provided"
@@ -38,20 +34,20 @@
                  :source-highlight true
                  :to-dir           "target/manual"}]
 
-  :profiles {:dev       {:plugins      [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]
+  :profiles {:dev       {:plugins      [[lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]
                                         [lein-shell "0.5.0"]
                                         [com.jakemccrary/lein-test-refresh "0.23.0"]]
                          :dependencies [[vvvvalvalval/datomock "0.2.2"]
                                         [io.forward/yaml "1.0.9"]
-                                        [org.apache.logging.log4j/log4j-core "2.11.1"]
-                                        [org.apache.logging.log4j/log4j-slf4j-impl "2.11.1"]]}
+                                        [org.apache.logging.log4j/log4j-core "2.11.2"]
+                                        [org.apache.logging.log4j/log4j-slf4j-impl "2.11.2"]]}
              :free      {:dependencies [[com.datomic/datomic-free "0.9.5697"
                                          :exclusions [org.slf4j/slf4j-nop]]]}
-             :docs      {:plugins      [[lein-codox "0.10.4"]
-                                        [lein-asciidoctor "0.1.16" :exclusions [org.slf4j/slf4j-api]]]
+             :docs      {:plugins      [[lein-codox "0.10.6"]
+                                        [lein-asciidoctor "0.1.17" :exclusions [org.slf4j/slf4j-api]]]
                          :dependencies [[codox-theme-rdash "0.1.2"]]}
              :ancient   {:plugins [[lein-ancient "0.6.15"]]}
-             :ultra     {:plugins [[venantius/ultra "0.5.2" :exclusions [org.clojure/clojure]]]}
+             :ultra     {:plugins [[venantius/ultra "0.6.0" :exclusions [org.clojure/clojure]]]}
              :test      {:resource-paths ["test/resources"]}
              :workframe {:plugins      [[s3-wagon-private "1.3.2" :exclusions [commons-logging]]]
                          :repositories [["workframe-private"

--- a/src/stillsuit/lacinia/scalars.clj
+++ b/src/stillsuit/lacinia/scalars.clj
@@ -3,8 +3,7 @@
 
   The intent here is to provide transformers for all of datomic's primitive values,
   though we ignore some oddball types like `:db.type/uri`."
-  (:require [com.walmartlabs.lacinia.schema :as schema]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [clojure.edn :as edn]
             [clojure.string :as str])
   (:import (java.util Date UUID)
@@ -12,83 +11,78 @@
            (java.time.format DateTimeFormatter)
            (clojure.lang Keyword)))
 
-(def parse-edn
+(defn parse-edn [value-str]
   "Parse the incoming string as EDN."
-  (schema/as-conformer edn/read-string))
+  (edn/read-string value-str))
 
 (def serialize-str
-  (schema/as-conformer str))
+  "Basic convert-to-string serializer, which just relies on good old `(str)`"
+  str)
 
-(def serialize-pr-str
-  (schema/as-conformer pr-str))
+(def serialize-pr-str pr-str)
 
-(def parse-iso8601
+(defn parse-iso8601
   "Parser which will parse dates in ISO-8601 format, convert them to UTC time, and return
   a `java.util.Date` result."
-  (schema/as-conformer
-   (fn [^String date-str]
-     ;; Java time libraries, from Hell's heart I stab at thee
-     (-> date-str
-         (LocalDateTime/parse DateTimeFormatter/ISO_DATE_TIME)
-         (.toInstant ZoneOffset/UTC)
-         Date/from))))
+  [^String date-str]
+  ;; Java time libraries, from Hell's heart I stab at thee
+  (-> date-str
+      (LocalDateTime/parse DateTimeFormatter/ISO_DATE_TIME)
+      (.toInstant ZoneOffset/UTC)
+      Date/from))
 
-(def serialize-iso8601
+(defn serialize-iso8601
   "Serializer which will serialize dates as ISO-8601 strings in the UTC timezone."
-  (schema/as-conformer
-   (fn [^Date date]
-     (-> date
-         .toInstant
-         (OffsetDateTime/ofInstant ZoneOffset/UTC)
-         (.format DateTimeFormatter/ISO_DATE_TIME)))))
+  [^Date date]
+  (-> date
+      .toInstant
+      (OffsetDateTime/ofInstant ZoneOffset/UTC)
+      (.format DateTimeFormatter/ISO_DATE_TIME)))
 
-(def parse-epoch-millisecs
+(defn parse-epoch-millisecs
   "Parser converting number of milliseconds since the UTC epoch (as a string) to a
   `java.util.Date` value."
-  (schema/as-conformer
-   (fn [^String msec-str]
-     (-> msec-str
-         Long/parseLong
-         Instant/ofEpochMilli
-         Date/from))))
+  [^String msec-str]
+  (-> msec-str
+      Long/parseLong
+      Instant/ofEpochMilli
+      Date/from))
 
-(def serialize-epoch-millisecs
+(defn serialize-epoch-millisecs
   "Serializer representing a `java.util.Date` object as a string representing the number
   of milliseconds since the UTC epoch."
-  (schema/as-conformer
-   (fn [^Date date]
-     (-> date
-         .getTime
-         .toString))))
+  [^Date date]
+  (-> date
+      .getTime
+      .toString))
 
-(def parse-uuid
-  (schema/as-conformer (fn [^String u] (UUID/fromString u))))
+(defn parse-uuid
+  [^String u]
+  (UUID/fromString u))
 
 (defn parse-as-value
   [type-convert]
-  (schema/as-conformer (fn [^String k] (type-convert k))))
+  ;(schema/as-conformer
+  (fn [^String k] (type-convert k)))
 
 (defn- strip-leading-colons
   [s]
   (str/replace s #"^:+" ""))
 
-(def keyword-parser
-  (schema/as-conformer
-   (fn keyword-parse-fn
-     [^String keyword-str]
-     (-> keyword-str
-         strip-leading-colons
-         keyword))))
+(defn keyword-parser
+  [^String keyword-str]
+  (-> keyword-str
+      strip-leading-colons
+      keyword))
 
 (defn keyword-serializer
   [with-colon?]
   (let [colon-xform (if with-colon? identity strip-leading-colons)]
-    (schema/as-conformer
-     (fn keyword-serialize-fn
-       [^Keyword k]
-       (-> k
-           str
-           colon-xform)))))
+    (fn keyword-serialize-fn
+      [^Keyword k]
+      (-> k
+          str
+          colon-xform))))
 
 (defn transformer-map
   "Given a base resolver map used attach scalar transformers to a lacinia schema, attach the
@@ -100,10 +94,10 @@
           :stillsuit.parse/iso8601                parse-iso8601
           :stillsuit.parse/epoch-millisecs        parse-epoch-millisecs
           :stillsuit.parse/keyword                keyword-parser
-          :stillsuit.parse/long                   (parse-as-value #(Long/parseLong ^String %))
-          :stillsuit.parse/bigint                 (parse-as-value bigint)
-          :stillsuit.parse/bigdec                 (parse-as-value bigdec)
-          :stillsuit.parse/double                 (parse-as-value #(Double/parseDouble ^String %))
+          :stillsuit.parse/long                   #(Long/parseLong ^String %)
+          :stillsuit.parse/bigint                 bigint
+          :stillsuit.parse/bigdec                 bigdec
+          :stillsuit.parse/double                 #(Double/parseDouble ^String %)
           :stillsuit.serialize/iso8601            serialize-iso8601
           :stillsuit.serialize/str                serialize-str
           :stillsuit.serialize/pr-str             serialize-pr-str

--- a/src/stillsuit/lacinia/scalars.clj
+++ b/src/stillsuit/lacinia/scalars.clj
@@ -60,11 +60,6 @@
   [^String u]
   (UUID/fromString u))
 
-(defn parse-as-value
-  [type-convert]
-  ;(schema/as-conformer
-  (fn [^String k] (type-convert k)))
-
 (defn- strip-leading-colons
   [s]
   (str/replace s #"^:+" ""))


### PR DESCRIPTION
This updates stillsuit to run on the most up-to-date stable version of lacinia, currently 0.32.0. Part of the change for this is rewriting the scalar transformers to use the [simplified scalar transformer API](https://github.com/walmartlabs/lacinia/blob/master/CHANGES.md#0310----4-jan-2019) introduced in 0.31.0. It also picks up a few ancillary dependency updates.